### PR TITLE
Linux script patches

### DIFF
--- a/Working Folder/Makefile
+++ b/Working Folder/Makefile
@@ -10,8 +10,8 @@
 #|                     V1.2 - August 2019                    |
 #|                                                           |
 #|                                                           |
-#|               Compilation Script for MacOS                |
-#|                 (may be for linux too ! ?)                |
+#|          Compilation Script for MacOS and Linux           |
+#|                                                           |
 #|                                                           |
 #\___________________________________________________________/
 #
@@ -76,7 +76,7 @@ CCFLAGS = --code-loc $(ADDR_CODE) --data-loc $(ADDR_DATA) --disable-warning 196 
 all:  $(REL_FILES) $(COM_FILES) clean emulator
 
 %.ihx: %.c
-	@SDCC $(CCFLAGS) $^
+	@sdcc $(CCFLAGS) $^
 	@echo "..•̀ᴗ•́)و .. $(CC) is Processing ... !"
 
 %.com: %.ihx

--- a/Working Folder/openMSX/emul_start.sh
+++ b/Working Folder/openMSX/emul_start.sh
@@ -1,13 +1,30 @@
-#!/bin/bash	
+#!/bin/bash
 # OpenMSX Start Script
 # The emulator will be started only if it's not already active
 
+#MacOS
+if [ "$(uname -s)" == "Darwin" ]; then
+	xopenmsx=`ps x | grep "openmsx " | grep -v grep`
+	 
+	if [ "${xopenmsx}" == "" ]; then
+	  echo "...Now Starting OpenMsx "
+	  ./openMSX/openMSX.app/Contents/MacOS/openmsx -script ./openMSX/emul_start_config.txt | NULL
+	else
+	  echo "...openMSX already running "
+	fi
 
-xopenmsx=`ps x | grep "openmsx " | grep -v grep`
- 
-if [ "${xopenmsx}" == "" ]; then
-  echo "...Now Starting OpenMsx "
-  ./openMSX/openMSX.app/Contents/MacOS/openmsx -script ./openMSX/emul_start_config.txt | NULL
+#Linux
+elif [ "$(uname -s)" == "Linux" ]; then
+	xopenmsx=`pgrep "openmsx"`
+	
+	if [ "${xopenmsx}" == "" ]; then
+		echo "...Now Starting OpenMSX "
+		/opt/openMSX/bin/openmsx -script ./openMSX/emul_start_config.txt
+	else
+		echo "...openMSX already running "
+	fi
+
+#Other
 else
-  echo "...openMSX already running "
+	echo "Failed to identify OS"
 fi

--- a/Working Folder/openMSX/emul_start.sh
+++ b/Working Folder/openMSX/emul_start.sh
@@ -1,12 +1,11 @@
-#!/bin/bash
 # OpenMSX Start Script
 # The emulator will be started only if it's not already active
 
 #MacOS
-if [ "$(uname -s)" == "Darwin" ]; then
+if [ "$(uname -s)" = "Darwin" ]; then
 	xopenmsx=`ps x | grep "openmsx " | grep -v grep`
 	 
-	if [ "${xopenmsx}" == "" ]; then
+	if [ "${xopenmsx}" = "" ]; then
 	  echo "...Now Starting OpenMsx "
 	  ./openMSX/openMSX.app/Contents/MacOS/openmsx -script ./openMSX/emul_start_config.txt | NULL
 	else
@@ -14,10 +13,10 @@ if [ "$(uname -s)" == "Darwin" ]; then
 	fi
 
 #Linux
-elif [ "$(uname -s)" == "Linux" ]; then
+elif [ "$(uname -s)" = "Linux" ]; then
 	xopenmsx=`pgrep "openmsx"`
 	
-	if [ "${xopenmsx}" == "" ]; then
+	if [ "${xopenmsx}" = "" ]; then
 		echo "...Now Starting OpenMSX "
 		/opt/openMSX/bin/openmsx -script ./openMSX/emul_start_config.txt
 	else

--- a/Working Folder/openMSX/readme.txt
+++ b/Working Folder/openMSX/readme.txt
@@ -1,1 +1,2 @@
-Copy here the OPenMSX Executable. Previously set with needed system roms.
+MacOS and Windows: Copy here the OpenMSX Executable. Previously set with needed system roms.
+Linux: This script assumes you've compiled the emulator with make install, which puts the executable in /opt/openMSX/bin. Change if needed.


### PR DESCRIPTION
The library's automation scripts were made only for Windows and MacOS. I've modified them to work on my linux system and decided to upload the changes if you are interested. I've tested this on my Debian 10 machine but it should work on any other distro.

Working Folder/Makefile
This called ```@SDCC``` , which is a problem as the linux shell is case sensitive. I've thus changed it to call ```@sdcc```.
The rest of the file was already completely compatible.

Working Folder/openMSX/emul_start.sh
This file now checks the machine's OS and executes a script accordingly. On MacOS, that would be the original code. On Linux, it opens /opt/openMSX/bin/openmsx. This is most likely the location of openmsx, as the emulator can only be installed from source, and its makefile places the executable there.
I've also made some syntax changes and removed the first line so this would work on any terminal emulator, not just bash.